### PR TITLE
Schedule generator (#4)

### DIFF
--- a/lib/schedule/generateSchedule.test.ts
+++ b/lib/schedule/generateSchedule.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import { generateSchedule, Team, Schedule } from './generateSchedule'
+
+function makeTeams(n: number): Team[] {
+  return Array.from({ length: n }, (_, i) => ({ id: String(i), name: `Team ${i}` }))
+}
+
+function gameCountPerTeam(schedule: Schedule, teams: Team[]): Map<string, number> {
+  const counts = new Map(teams.map((t) => [t.id, 0]))
+  for (const draw of schedule.draws) {
+    for (const game of draw.games) {
+      counts.set(game.homeTeamId, (counts.get(game.homeTeamId) ?? 0) + 1)
+      counts.set(game.awayTeamId, (counts.get(game.awayTeamId) ?? 0) + 1)
+    }
+  }
+  return counts
+}
+
+function byeCountPerTeam(schedule: Schedule, teams: Team[]): Map<string, number> {
+  const counts = new Map(teams.map((t) => [t.id, 0]))
+  for (const draw of schedule.draws) {
+    for (const id of draw.byeTeamIds) {
+      counts.set(id, (counts.get(id) ?? 0) + 1)
+    }
+  }
+  return counts
+}
+
+describe('generateSchedule', () => {
+  it('no team plays itself', () => {
+    const teams = makeTeams(6)
+    const schedule = generateSchedule(teams, 3, 5)
+    for (const draw of schedule.draws) {
+      for (const game of draw.games) {
+        expect(game.homeTeamId).not.toBe(game.awayTeamId)
+      }
+    }
+  })
+
+  it('each draw has at most sheets games', () => {
+    const teams = makeTeams(8)
+    const sheets = 3
+    const schedule = generateSchedule(teams, sheets, 7)
+    for (const draw of schedule.draws) {
+      expect(draw.games.length).toBeLessThanOrEqual(sheets)
+    }
+  })
+
+  it('no team plays more than once per draw', () => {
+    const teams = makeTeams(8)
+    const schedule = generateSchedule(teams, 4, 7)
+    for (const draw of schedule.draws) {
+      const seen = new Set<string>()
+      for (const game of draw.games) {
+        expect(seen.has(game.homeTeamId)).toBe(false)
+        expect(seen.has(game.awayTeamId)).toBe(false)
+        seen.add(game.homeTeamId)
+        seen.add(game.awayTeamId)
+      }
+    }
+  })
+
+  it('all sheet numbers are within [1, sheets]', () => {
+    const teams = makeTeams(6)
+    const sheets = 3
+    const schedule = generateSchedule(teams, sheets, 5)
+    for (const draw of schedule.draws) {
+      for (const game of draw.games) {
+        expect(game.sheet).toBeGreaterThanOrEqual(1)
+        expect(game.sheet).toBeLessThanOrEqual(sheets)
+      }
+    }
+  })
+
+  it('byes distributed evenly (max difference of 1) for odd team count', () => {
+    const teams = makeTeams(7)
+    const schedule = generateSchedule(teams, 3, 7)
+    const byeCounts = byeCountPerTeam(schedule, teams)
+    const values = [...byeCounts.values()]
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    expect(max - min).toBeLessThanOrEqual(1)
+  })
+
+  it('even team count produces no byes when sheets are sufficient', () => {
+    const teams = makeTeams(6)
+    const schedule = generateSchedule(teams, 3, 5)
+    for (const draw of schedule.draws) {
+      expect(draw.byeTeamIds.length).toBe(0)
+    }
+  })
+
+  it('minimum viable: 2 teams, 1 sheet, 1 week', () => {
+    const teams = makeTeams(2)
+    const schedule = generateSchedule(teams, 1, 1)
+    expect(schedule.draws).toHaveLength(1)
+    expect(schedule.draws[0].games).toHaveLength(1)
+    expect(schedule.draws[0].byeTeamIds).toHaveLength(0)
+  })
+
+  it('produces correct number of draws', () => {
+    const teams = makeTeams(6)
+    const schedule = generateSchedule(teams, 3, 8)
+    expect(schedule.draws).toHaveLength(8)
+    expect(schedule.draws.map((d) => d.weekNumber)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  it('larger league: 8 teams, 4 sheets, 10 weeks', () => {
+    const teams = makeTeams(8)
+    const schedule = generateSchedule(teams, 4, 10)
+    expect(schedule.draws).toHaveLength(10)
+    for (const draw of schedule.draws) {
+      expect(draw.games.length).toBeLessThanOrEqual(4)
+      expect(draw.byeTeamIds.length).toBe(0)
+    }
+    // Each team should play in every draw (8 teams, 4 sheets = 4 games = 8 team slots, no byes)
+    for (const draw of schedule.draws) {
+      const playing = new Set([
+        ...draw.games.map((g) => g.homeTeamId),
+        ...draw.games.map((g) => g.awayTeamId),
+      ])
+      expect(playing.size).toBe(8)
+    }
+  })
+})

--- a/lib/schedule/generateSchedule.ts
+++ b/lib/schedule/generateSchedule.ts
@@ -1,0 +1,88 @@
+export interface Team {
+  id: string
+  name: string
+}
+
+export interface Game {
+  homeTeamId: string
+  awayTeamId: string
+  sheet: number
+}
+
+export interface Draw {
+  weekNumber: number
+  games: Game[]
+  byeTeamIds: string[]
+}
+
+export interface Schedule {
+  draws: Draw[]
+}
+
+/**
+ * Berger table (round-robin) for n teams.
+ * Returns an array of rounds; each round is an array of [home, away] index pairs.
+ * If n is odd, one team per round has a bye (represented as index n-1 paired with -1).
+ */
+function bergerRounds(n: number): Array<Array<[number, number]>> {
+  const isOdd = n % 2 !== 0
+  const count = isOdd ? n : n  // number of participants (odd adds a dummy)
+  const effective = isOdd ? n + 1 : n
+  const rounds: Array<Array<[number, number]>> = []
+
+  const seats = Array.from({ length: effective }, (_, i) => i)
+
+  for (let round = 0; round < effective - 1; round++) {
+    const pairs: Array<[number, number]> = []
+    for (let i = 0; i < effective / 2; i++) {
+      const home = seats[i]
+      const away = seats[effective - 1 - i]
+      pairs.push([home, away])
+    }
+    rounds.push(pairs)
+    // Rotate: fix seat 0, rotate the rest
+    const last = seats[effective - 1]
+    for (let i = effective - 1; i > 1; i--) seats[i] = seats[i - 1]
+    seats[1] = last
+  }
+
+  return rounds
+}
+
+export function generateSchedule(teams: Team[], sheets: number, weeks: number): Schedule {
+  const n = teams.length
+  if (n < 2) return { draws: [] }
+
+  const roundRobinRounds = bergerRounds(n)
+  const draws: Draw[] = []
+
+  for (let week = 0; week < weeks; week++) {
+    const round = roundRobinRounds[week % roundRobinRounds.length]
+    const games: Game[] = []
+    const byeTeamIds: string[] = []
+    let sheetNum = 1
+
+    for (const [homeIdx, awayIdx] of round) {
+      const isOddBye = homeIdx >= n || awayIdx >= n
+      if (isOddBye) {
+        const realIdx = homeIdx < n ? homeIdx : awayIdx
+        byeTeamIds.push(teams[realIdx].id)
+        continue
+      }
+      if (sheetNum > sheets) {
+        // More games than sheets — excess teams get a bye this draw
+        byeTeamIds.push(teams[homeIdx].id, teams[awayIdx].id)
+        continue
+      }
+      games.push({
+        homeTeamId: teams[homeIdx].id,
+        awayTeamId: teams[awayIdx].id,
+        sheet: sheetNum++,
+      })
+    }
+
+    draws.push({ weekNumber: week + 1, games, byeTeamIds })
+  }
+
+  return { draws }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "curlingleaguetest-balancing",
+  "name": "curlingleaguetest-schedule",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "curlingleaguetest-balancing",
+      "name": "curlingleaguetest-schedule",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "curlingleaguetest-balancing",
+  "name": "curlingleaguetest-schedule",
   "version": "1.0.0",
   "description": "init",
   "main": "index.js",


### PR DESCRIPTION
## Parent
#1

## Summary
- Pure `generateSchedule(teams, sheets, weeks)` function in `lib/schedule/generateSchedule.ts`
- Uses Berger table algorithm for round-robin matchup generation
- Handles odd team counts with evenly distributed byes (max 1 bye difference between any two teams)
- Respects sheet count per draw; excess teams get a bye when sheets < teams/2

## Test plan
- [ ] `npm test` — 9/9 passing (verified)
- No team plays itself
- Max `sheets` games per draw
- No team in two games per draw
- Byes distributed evenly (odd counts)
- Correct draw count and week numbers

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)