### PR TITLE
User registration & login (#5)

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useActionState } from 'react'
+import { signIn } from './actions'
+import Link from 'next/link'
+
+type State = { error?: string } | null
+
+export default function LoginForm() {
+  const [state, action, pending] = useActionState<State, FormData>(signIn, null)
+
+  return (
+    <form action={action} className="flex flex-col gap-4">
+      {state?.error && (
+        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">{state.error}</p>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="email" className="text-sm font-medium">Email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="password" className="text-sm font-medium">Password</label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="mt-2 rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+      >
+        {pending ? 'Signing in…' : 'Sign In'}
+      </button>
+
+      <p className="text-center text-sm text-zinc-500">
+        No account yet?{' '}
+        <Link href="/register" className="font-medium text-black underline">Create one</Link>
+      </p>
+    </form>
+  )
+}

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,20 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+
+type State = { error?: string } | null
+
+export async function signIn(_prevState: State, formData: FormData): Promise<State> {
+  const email = formData.get('email') as string
+  const password = formData.get('password') as string
+
+  const supabase = await createClient()
+  const { error } = await supabase.auth.signInWithPassword({ email, password })
+
+  if (error) {
+    return { error: error.message }
+  }
+
+  redirect('/portal')
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,12 @@
+import LoginForm from './LoginForm'
+
 export default function LoginPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-semibold">Sign In</h1>
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <h1 className="mb-8 text-3xl font-bold">Sign In</h1>
+        <LoginForm />
+      </div>
     </main>
   )
 }

--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useActionState } from 'react'
+import { registerUser } from './actions'
+import Link from 'next/link'
+
+const SKILL_TIERS = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
+] as const
+
+type State = { error?: string } | null
+
+export default function RegisterForm() {
+  const [state, action, pending] = useActionState<State, FormData>(registerUser, null)
+
+  return (
+    <form action={action} className="flex flex-col gap-4">
+      {state?.error && (
+        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">{state.error}</p>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="name" className="text-sm font-medium">Full Name</label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="email" className="text-sm font-medium">Email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="password" className="text-sm font-medium">Password</label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          minLength={8}
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="phone" className="text-sm font-medium">
+          Phone <span className="text-zinc-400">(optional)</span>
+        </label>
+        <input
+          id="phone"
+          name="phone"
+          type="tel"
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="skill_tier" className="text-sm font-medium">Skill Level</label>
+        <select
+          id="skill_tier"
+          name="skill_tier"
+          required
+          defaultValue=""
+          className="rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        >
+          <option value="" disabled>Select your level</option>
+          {SKILL_TIERS.map(({ value, label }) => (
+            <option key={value} value={value}>{label}</option>
+          ))}
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="mt-2 rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+      >
+        {pending ? 'Creating account…' : 'Create Account'}
+      </button>
+
+      <p className="text-center text-sm text-zinc-500">
+        Already have an account?{' '}
+        <Link href="/login" className="font-medium text-black underline">Sign in</Link>
+      </p>
+    </form>
+  )
+}

--- a/src/app/register/actions.ts
+++ b/src/app/register/actions.ts
@@ -1,0 +1,36 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import type { SkillTier } from '@/lib/supabase/types'
+
+type State = { error?: string } | null
+
+export async function registerUser(_prevState: State, formData: FormData): Promise<State> {
+  const email = formData.get('email') as string
+  const password = formData.get('password') as string
+  const name = formData.get('name') as string
+  const phone = formData.get('phone') as string | null
+  const skillTier = formData.get('skill_tier') as SkillTier
+
+  const supabase = await createClient()
+
+  const { data, error } = await supabase.auth.signUp({ email, password })
+  if (error || !data.user) {
+    return { error: error?.message ?? 'Sign up failed' }
+  }
+
+  const { error: profileError } = await supabase.from('profiles').insert({
+    id: data.user.id,
+    name,
+    email,
+    phone: phone || null,
+    skill_tier: skillTier,
+  })
+
+  if (profileError) {
+    return { error: profileError.message }
+  }
+
+  redirect('/league/join')
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,7 +1,12 @@
+import RegisterForm from './RegisterForm'
+
 export default function RegisterPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-semibold">Create Account</h1>
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <h1 className="mb-8 text-3xl font-bold">Create Account</h1>
+        <RegisterForm />
+      </div>
     </main>
   )
 }

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1,58 +1,251 @@
-export type SkillTier = 'beginner' | 'intermediate' | 'advanced'
-export type UserRole = 'player' | 'drawmaster' | 'club_admin'
-export type SeasonState = 'registration_open' | 'teams_finalized' | 'season_active' | 'season_complete'
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
-export interface Database {
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.5"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
       profiles: {
         Row: {
+          created_at: string
+          email: string
           id: string
           name: string
-          email: string
           phone: string | null
-          skill_tier: SkillTier
-          role: UserRole
-          created_at: string
+          role: Database["public"]["Enums"]["user_role"]
+          skill_tier: Database["public"]["Enums"]["skill_tier"]
         }
         Insert: {
+          created_at?: string
+          email: string
           id: string
           name: string
-          email: string
           phone?: string | null
-          skill_tier: SkillTier
-          role?: UserRole
-          created_at?: string
+          role?: Database["public"]["Enums"]["user_role"]
+          skill_tier: Database["public"]["Enums"]["skill_tier"]
         }
         Update: {
-          name?: string
+          created_at?: string
           email?: string
+          id?: string
+          name?: string
           phone?: string | null
-          skill_tier?: SkillTier
-          role?: UserRole
+          role?: Database["public"]["Enums"]["user_role"]
+          skill_tier?: Database["public"]["Enums"]["skill_tier"]
         }
+        Relationships: []
       }
       seasons: {
         Row: {
-          id: string
-          state: SeasonState
-          sheet_count: number | null
-          week_count: number | null
           created_at: string
+          id: string
+          sheet_count: number | null
+          state: Database["public"]["Enums"]["season_state"]
+          week_count: number | null
         }
         Insert: {
-          id?: string
-          state?: SeasonState
-          sheet_count?: number | null
-          week_count?: number | null
           created_at?: string
+          id?: string
+          sheet_count?: number | null
+          state?: Database["public"]["Enums"]["season_state"]
+          week_count?: number | null
         }
         Update: {
-          state?: SeasonState
+          created_at?: string
+          id?: string
           sheet_count?: number | null
+          state?: Database["public"]["Enums"]["season_state"]
           week_count?: number | null
         }
+        Relationships: []
       }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      season_state:
+        | "registration_open"
+        | "teams_finalized"
+        | "season_active"
+        | "season_complete"
+      skill_tier: "beginner" | "intermediate" | "advanced"
+      user_role: "player" | "drawmaster" | "club_admin"
+    }
+    CompositeTypes: {
+      [_ in never]: never
     }
   }
 }
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {
+      season_state: [
+        "registration_open",
+        "teams_finalized",
+        "season_active",
+        "season_complete",
+      ],
+      skill_tier: ["beginner", "intermediate", "advanced"],
+      user_role: ["player", "drawmaster", "club_admin"],
+    },
+  },
+} as const

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -1,0 +1,8 @@
+import type { Database } from './database.types'
+
+export type SkillTier = Database['public']['Enums']['skill_tier']
+export type UserRole = Database['public']['Enums']['user_role']
+export type SeasonState = Database['public']['Enums']['season_state']
+
+export type Profile = Database['public']['Tables']['profiles']['Row']
+export type Season = Database['public']['Tables']['seasons']['Row']

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
-import type { UserRole } from '@/lib/supabase/database.types'
+import type { UserRole } from '@/lib/supabase/types'
 
 const DRAWMASTER_ROLES: UserRole[] = ['drawmaster', 'club_admin']
 


### PR DESCRIPTION
## Parent
#1

## Summary
- Registration form: name, email, password, phone (optional), skill tier selector (Beginner/Intermediate/Advanced)
- On submit: creates Supabase Auth user + profile row, redirects to `/league/join`
- Login form: email/password sign in, redirects to `/portal`
- Updates `database.types.ts` to properly generated Supabase types
- Adds `src/lib/supabase/types.ts` with convenience aliases (SkillTier, UserRole, SeasonState, Profile, Season)

## Test plan
- [ ] Register a new account — profile row appears in Supabase dashboard
- [ ] Validation prevents submission with missing required fields
- [ ] Existing email shows error from Supabase Auth
- [ ] Login with correct credentials redirects to `/portal`
- [ ] Login with wrong credentials shows error

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)