### PR TITLE
Season state machine & role management (#6)

### DIFF
--- a/src/app/admin/RoleManagementPanel.tsx
+++ b/src/app/admin/RoleManagementPanel.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useTransition } from 'react'
+import { updateUserRole } from './role.actions'
+import type { UserRole } from '@/lib/supabase/types'
+
+const ROLE_LABELS: Record<UserRole, string> = {
+  player: 'Player',
+  drawmaster: 'Drawmaster',
+  club_admin: 'Club Admin',
+}
+
+interface User {
+  id: string
+  name: string
+  email: string
+  role: UserRole
+}
+
+interface Props {
+  users: User[]
+  currentUserId: string
+}
+
+export default function RoleManagementPanel({ users, currentUserId }: Props) {
+  const [pending, startTransition] = useTransition()
+
+  function handleRoleChange(userId: string, newRole: UserRole) {
+    startTransition(async () => {
+      const result = await updateUserRole(userId, newRole)
+      if (result?.error) alert(result.error)
+    })
+  }
+
+  return (
+    <section className="rounded-lg border p-6">
+      <h2 className="mb-4 text-xl font-semibold">Role Management</h2>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-zinc-500">
+              <th className="pb-2 pr-4 font-medium">Name</th>
+              <th className="pb-2 pr-4 font-medium">Email</th>
+              <th className="pb-2 font-medium">Role</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {users.map((user) => (
+              <tr key={user.id} className="py-2">
+                <td className="py-2 pr-4 font-medium">{user.name}</td>
+                <td className="py-2 pr-4 text-zinc-500">{user.email}</td>
+                <td className="py-2">
+                  {user.id === currentUserId ? (
+                    <span className="text-zinc-400">{ROLE_LABELS[user.role]} (you)</span>
+                  ) : (
+                    <select
+                      value={user.role}
+                      disabled={pending}
+                      onChange={(e) => handleRoleChange(user.id, e.target.value as UserRole)}
+                      className="rounded border px-2 py-1 text-sm disabled:opacity-50"
+                    >
+                      {(Object.keys(ROLE_LABELS) as UserRole[]).map((role) => (
+                        <option key={role} value={role}>{ROLE_LABELS[role]}</option>
+                      ))}
+                    </select>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/src/app/admin/SeasonStatePanel.tsx
+++ b/src/app/admin/SeasonStatePanel.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useTransition } from 'react'
+import { advanceSeasonState } from './season.actions'
+import type { SeasonState } from '@/lib/supabase/types'
+
+const STATE_LABELS: Record<SeasonState, string> = {
+  registration_open: 'Registration Open',
+  teams_finalized: 'Teams Finalized',
+  season_active: 'Season Active',
+  season_complete: 'Season Complete',
+}
+
+const NEXT_ACTION_LABELS: Partial<Record<SeasonState, string>> = {
+  registration_open: 'Finalize Teams',
+  teams_finalized: 'Start Season',
+  season_active: 'Complete Season',
+}
+
+const STATES: SeasonState[] = ['registration_open', 'teams_finalized', 'season_active', 'season_complete']
+
+interface Props {
+  season: { id: string; state: SeasonState } | null
+}
+
+export default function SeasonStatePanel({ season }: Props) {
+  const [pending, startTransition] = useTransition()
+
+  if (!season) {
+    return (
+      <section className="rounded-lg border p-6">
+        <h2 className="mb-2 text-xl font-semibold">Season</h2>
+        <p className="text-zinc-500">No season found.</p>
+      </section>
+    )
+  }
+
+  const currentIdx = STATES.indexOf(season.state)
+  const nextLabel = NEXT_ACTION_LABELS[season.state]
+
+  function handleAdvance() {
+    startTransition(async () => {
+      await advanceSeasonState(season!.id, season!.state)
+    })
+  }
+
+  return (
+    <section className="rounded-lg border p-6">
+      <h2 className="mb-4 text-xl font-semibold">Season State</h2>
+
+      <ol className="mb-6 flex gap-2">
+        {STATES.map((state, idx) => (
+          <li key={state} className="flex items-center gap-2">
+            <span className={`rounded-full px-3 py-1 text-sm font-medium ${
+              idx === currentIdx
+                ? 'bg-black text-white'
+                : idx < currentIdx
+                  ? 'bg-zinc-200 text-zinc-500 line-through'
+                  : 'bg-zinc-100 text-zinc-400'
+            }`}>
+              {STATE_LABELS[state]}
+            </span>
+            {idx < STATES.length - 1 && <span className="text-zinc-300">→</span>}
+          </li>
+        ))}
+      </ol>
+
+      {nextLabel && (
+        <button
+          onClick={handleAdvance}
+          disabled={pending}
+          className="rounded-md bg-black px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+        >
+          {pending ? 'Updating…' : nextLabel}
+        </button>
+      )}
+    </section>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,51 @@
-export default function AdminPage() {
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import type { UserRole, SeasonState } from '@/lib/supabase/types'
+import SeasonStatePanel from './SeasonStatePanel'
+import RoleManagementPanel from './RoleManagementPanel'
+
+export default async function AdminPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profileData } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  const profile = profileData as { role: UserRole } | null
+
+  if (!profile || !['drawmaster', 'club_admin'].includes(profile.role)) {
+    redirect('/portal')
+  }
+
+  const { data: seasonData } = await supabase
+    .from('seasons')
+    .select('id, state')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  const season = seasonData as { id: string; state: SeasonState } | null
+
+  const { data: usersData } = await supabase
+    .from('profiles')
+    .select('id, name, email, role')
+    .order('name')
+
+  const users = (usersData ?? []) as { id: string; name: string; email: string; role: UserRole }[]
+
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-semibold">Admin Dashboard</h1>
+    <main className="mx-auto max-w-4xl p-8">
+      <h1 className="mb-8 text-3xl font-bold">Admin Dashboard</h1>
+      <div className="flex flex-col gap-8">
+        <SeasonStatePanel season={season} />
+        {profile.role === 'club_admin' && (
+          <RoleManagementPanel users={users} currentUserId={user.id} />
+        )}
+      </div>
     </main>
   )
 }

--- a/src/app/admin/role.actions.ts
+++ b/src/app/admin/role.actions.ts
@@ -1,0 +1,49 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '@/lib/supabase/server'
+import type { UserRole } from '@/lib/supabase/types'
+
+export async function updateUserRole(targetUserId: string, newRole: UserRole) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Unauthorized' }
+
+  if (targetUserId === user.id) return { error: 'Cannot change your own role' }
+
+  const { data: currentProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (currentProfile?.role !== 'club_admin') return { error: 'Unauthorized' }
+
+  // Prevent removing the last admin
+  if (newRole !== 'club_admin') {
+    const { count } = await supabase
+      .from('profiles')
+      .select('id', { count: 'exact', head: true })
+      .eq('role', 'club_admin')
+
+    if ((count ?? 0) <= 1) {
+      const { data: target } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', targetUserId)
+        .single()
+      if (target?.role === 'club_admin') {
+        return { error: 'Cannot remove the last club admin' }
+      }
+    }
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ role: newRole })
+    .eq('id', targetUserId)
+
+  if (error) return { error: error.message }
+
+  revalidatePath('/admin')
+}

--- a/src/app/admin/season.actions.ts
+++ b/src/app/admin/season.actions.ts
@@ -1,0 +1,38 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { createClient } from '@/lib/supabase/server'
+import type { SeasonState } from '@/lib/supabase/types'
+
+const VALID_TRANSITIONS: Record<SeasonState, SeasonState | null> = {
+  registration_open: 'teams_finalized',
+  teams_finalized: 'season_active',
+  season_active: 'season_complete',
+  season_complete: null,
+}
+
+export async function advanceSeasonState(seasonId: string, currentState: SeasonState) {
+  const nextState = VALID_TRANSITIONS[currentState]
+  if (!nextState) return { error: 'Season is already complete' }
+
+  const supabase = await createClient()
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', (await supabase.auth.getUser()).data.user?.id ?? '')
+    .single()
+
+  if (!profile || !['drawmaster', 'club_admin'].includes(profile.role)) {
+    return { error: 'Unauthorized' }
+  }
+
+  const { error } = await supabase
+    .from('seasons')
+    .update({ state: nextState })
+    .eq('id', seasonId)
+
+  if (error) return { error: error.message }
+
+  revalidatePath('/admin')
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
-import type { UserRole } from '@/lib/supabase/types'
+import type { UserRole } from "@/lib/supabase/types"
 
 const DRAWMASTER_ROLES: UserRole[] = ['drawmaster', 'club_admin']
 


### PR DESCRIPTION
## Parent
#1

## Summary
- Season state panel: displays current state as a progress indicator, lets drawmasters/admins advance one-way through `registration_open → teams_finalized → season_active → season_complete`
- Role management panel (club admin only): table of all users with role dropdowns, prevents changing your own role, prevents removing the last club admin
- Admin page is server-rendered and guards against non-drawmaster access

## Test plan
- [ ] Drawmaster can see season state panel and advance to next state
- [ ] State cannot go backwards
- [ ] Club admin sees role management panel; drawmaster does not
- [ ] Cannot demote yourself
- [ ] Cannot remove the last club admin

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)