### PR TITLE
Player directory (#7)

### DIFF
--- a/src/app/admin/directory/PlayerDirectory.tsx
+++ b/src/app/admin/directory/PlayerDirectory.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useState } from 'react'
+import type { SkillTier } from '@/lib/supabase/types'
+
+const TIER_LABELS: Record<SkillTier, string> = {
+  beginner: 'Beginner',
+  intermediate: 'Intermediate',
+  advanced: 'Advanced',
+}
+
+interface Player {
+  id: string
+  name: string
+  email: string
+  phone: string | null
+  skill_tier: SkillTier
+  role: string
+}
+
+export default function PlayerDirectory({ players }: { players: Player[] }) {
+  const [query, setQuery] = useState('')
+
+  const filtered = query.trim()
+    ? players.filter((p) =>
+        p.name.toLowerCase().includes(query.toLowerCase())
+      )
+    : players
+
+  return (
+    <div className="flex flex-col gap-4">
+      <input
+        type="search"
+        placeholder="Search by name…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="w-full max-w-sm rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+      />
+
+      <p className="text-sm text-zinc-500">{filtered.length} player{filtered.length !== 1 ? 's' : ''}</p>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50">
+            <tr className="border-b text-left text-zinc-500">
+              <th className="px-4 py-3 font-medium">Name</th>
+              <th className="px-4 py-3 font-medium">Email</th>
+              <th className="px-4 py-3 font-medium">Phone</th>
+              <th className="px-4 py-3 font-medium">Skill</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-zinc-400">
+                  No players found
+                </td>
+              </tr>
+            ) : (
+              filtered.map((player) => (
+                <tr key={player.id} className="hover:bg-zinc-50">
+                  <td className="px-4 py-3 font-medium">{player.name}</td>
+                  <td className="px-4 py-3">
+                    <a href={`mailto:${player.email}`} className="text-blue-600 hover:underline">
+                      {player.email}
+                    </a>
+                  </td>
+                  <td className="px-4 py-3 text-zinc-500">
+                    {player.phone
+                      ? <a href={`tel:${player.phone}`} className="hover:underline">{player.phone}</a>
+                      : <span className="text-zinc-300">—</span>
+                    }
+                  </td>
+                  <td className="px-4 py-3 text-zinc-500">{TIER_LABELS[player.skill_tier]}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/directory/page.tsx
+++ b/src/app/admin/directory/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import PlayerDirectory from './PlayerDirectory'
+
+export default async function DirectoryPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile || !['drawmaster', 'club_admin'].includes(profile.role as string)) {
+    redirect('/portal')
+  }
+
+  const { data: players } = await supabase
+    .from('profiles')
+    .select('id, name, email, phone, skill_tier, role')
+    .order('name')
+
+  return (
+    <main className="mx-auto max-w-4xl p-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Player Directory</h1>
+        <a href="/admin" className="text-sm text-zinc-500 hover:text-black">← Admin</a>
+      </div>
+      <PlayerDirectory players={players ?? []} />
+    </main>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -42,6 +42,12 @@ export default async function AdminPage() {
       <h1 className="mb-8 text-3xl font-bold">Admin Dashboard</h1>
       <div className="flex flex-col gap-8">
         <SeasonStatePanel season={season} />
+        <a
+          href="/admin/directory"
+          className="inline-flex items-center gap-2 text-sm font-medium text-blue-600 hover:underline"
+        >
+          Player Directory →
+        </a>
         {profile.role === 'club_admin' && (
           <RoleManagementPanel users={users} currentUserId={user.id} />
         )}


### PR DESCRIPTION
## Parent
#1

## Summary
- Searchable player table at `/admin/directory` with name, email (mailto link), phone (tel link), and skill tier
- Filtered client-side by name as you type
- Link added to admin dashboard
- Blocked to players via existing middleware

## Test plan
- [ ] Visit `/admin/directory` as drawmaster — see all registered users
- [ ] Search filters by name
- [ ] Player cannot access `/admin/directory`

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/claude-code)