### PR TITLE
League registration & teammate preferences (#8)

### DIFF
--- a/src/app/league/join/JoinLeagueForm.tsx
+++ b/src/app/league/join/JoinLeagueForm.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import TeammateSearch from './TeammateSearch'
+import { joinLeague, leaveLeague } from './actions'
+import type { SkillTier } from '@/lib/supabase/types'
+
+interface Player {
+  id: string
+  name: string
+  skill_tier: SkillTier
+}
+
+interface Props {
+  seasonId: string
+  isRegistered: boolean
+}
+
+export default function JoinLeagueForm({ seasonId, isRegistered }: Props) {
+  const [teammates, setTeammates] = useState<Player[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  function handleJoin() {
+    setError(null)
+    startTransition(async () => {
+      const result = await joinLeague(seasonId, teammates.map((t) => t.id))
+      if (result?.error) setError(result.error)
+    })
+  }
+
+  function handleLeave() {
+    setError(null)
+    startTransition(async () => {
+      const result = await leaveLeague(seasonId)
+      if (result?.error) setError(result.error)
+    })
+  }
+
+  if (isRegistered) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="rounded-md bg-green-50 px-4 py-3 text-sm text-green-700">
+          You are registered for this season.
+        </div>
+        {error && (
+          <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p>
+        )}
+        <button
+          onClick={handleLeave}
+          disabled={pending}
+          className="w-fit rounded-md border border-red-300 px-4 py-2 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+        >
+          {pending ? 'Leaving…' : 'Leave League'}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {error && (
+        <p className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">
+          Preferred Teammates <span className="text-zinc-400">(optional, up to 4)</span>
+        </label>
+        <p className="text-xs text-zinc-500">
+          These players will be guaranteed on your team. Search by name.
+        </p>
+        <TeammateSearch selected={teammates} onChange={setTeammates} max={4} />
+      </div>
+
+      <button
+        onClick={handleJoin}
+        disabled={pending}
+        className="w-fit rounded-md bg-black px-6 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+      >
+        {pending ? 'Joining…' : 'Join League'}
+      </button>
+    </div>
+  )
+}

--- a/src/app/league/join/TeammateSearch.tsx
+++ b/src/app/league/join/TeammateSearch.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useState, useRef, useEffect, useTransition } from 'react'
+import { searchPlayers } from './actions'
+import type { SkillTier } from '@/lib/supabase/types'
+
+const TIER_LABELS: Record<SkillTier, string> = {
+  beginner: 'Beginner',
+  intermediate: 'Intermediate',
+  advanced: 'Advanced',
+}
+
+interface Player {
+  id: string
+  name: string
+  skill_tier: SkillTier
+}
+
+interface Props {
+  selected: Player[]
+  onChange: (players: Player[]) => void
+  max?: number
+}
+
+export default function TeammateSearch({ selected, onChange, max = 4 }: Props) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Player[]>([])
+  const [open, setOpen] = useState(false)
+  const [, startTransition] = useTransition()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (query.length < 2) { setResults([]); return }
+    startTransition(async () => {
+      const data = await searchPlayers(query)
+      const selectedIds = new Set(selected.map((p) => p.id))
+      setResults((data as Player[]).filter((p) => !selectedIds.has(p.id)))
+      setOpen(true)
+    })
+  }, [query, selected])
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node) &&
+        !inputRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function addPlayer(player: Player) {
+    onChange([...selected, player])
+    setQuery('')
+    setResults([])
+    setOpen(false)
+    inputRef.current?.focus()
+  }
+
+  function removePlayer(id: string) {
+    onChange(selected.filter((p) => p.id !== id))
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-2">
+        {selected.map((player) => (
+          <span
+            key={player.id}
+            className="flex items-center gap-1 rounded-full bg-zinc-100 px-3 py-1 text-sm"
+          >
+            {player.name}
+            <button
+              type="button"
+              onClick={() => removePlayer(player.id)}
+              className="text-zinc-400 hover:text-black"
+              aria-label={`Remove ${player.name}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+
+      {selected.length < max && (
+        <div className="relative">
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search by name…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => results.length > 0 && setOpen(true)}
+            className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+          />
+          {open && results.length > 0 && (
+            <div
+              ref={dropdownRef}
+              className="absolute z-10 mt-1 w-full rounded-md border bg-white shadow-md"
+            >
+              {results.map((player) => (
+                <button
+                  key={player.id}
+                  type="button"
+                  onClick={() => addPlayer(player)}
+                  className="flex w-full items-center justify-between px-4 py-2 text-sm hover:bg-zinc-50"
+                >
+                  <span>{player.name}</span>
+                  <span className="text-xs text-zinc-400">{TIER_LABELS[player.skill_tier]}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {selected.length >= max && (
+        <p className="text-xs text-zinc-400">Maximum {max} teammates selected</p>
+      )}
+    </div>
+  )
+}

--- a/src/app/league/join/actions.ts
+++ b/src/app/league/join/actions.ts
@@ -1,0 +1,88 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+
+export async function joinLeague(seasonId: string, preferredUserIds: string[]) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const { data: season } = await supabase
+    .from('seasons')
+    .select('state')
+    .eq('id', seasonId)
+    .single()
+
+  if (season?.state !== 'registration_open') {
+    return { error: 'League registration is closed' }
+  }
+
+  const { error: regError } = await supabase
+    .from('league_registrations')
+    .insert({ user_id: user.id, season_id: seasonId })
+
+  if (regError) return { error: regError.message }
+
+  if (preferredUserIds.length > 0) {
+    const prefs = preferredUserIds.map((preferred_user_id) => ({
+      from_user_id: user.id,
+      preferred_user_id,
+      season_id: seasonId,
+    }))
+    const { error: prefError } = await supabase
+      .from('teammate_preferences')
+      .insert(prefs)
+    if (prefError) return { error: prefError.message }
+  }
+
+  redirect('/portal')
+}
+
+export async function leaveLeague(seasonId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { error: 'Not authenticated' }
+
+  const { data: season } = await supabase
+    .from('seasons')
+    .select('state')
+    .eq('id', seasonId)
+    .single()
+
+  if (season?.state !== 'registration_open') {
+    return { error: 'Cannot leave after registration has closed' }
+  }
+
+  await supabase
+    .from('teammate_preferences')
+    .delete()
+    .eq('from_user_id', user.id)
+    .eq('season_id', seasonId)
+
+  await supabase
+    .from('league_registrations')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('season_id', seasonId)
+
+  revalidatePath('/league/join')
+}
+
+export async function searchPlayers(query: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
+
+  if (query.trim().length < 2) return []
+
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, name, skill_tier')
+    .ilike('name', `%${query}%`)
+    .neq('id', user.id)
+    .limit(8)
+
+  return data ?? []
+}

--- a/src/app/league/join/page.tsx
+++ b/src/app/league/join/page.tsx
@@ -1,7 +1,52 @@
-export default function LeagueJoinPage() {
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import JoinLeagueForm from './JoinLeagueForm'
+
+export default async function LeagueJoinPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  const { data: season } = await supabase
+    .from('seasons')
+    .select('id, state')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (!season) {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <p className="text-zinc-500">No active season found.</p>
+      </main>
+    )
+  }
+
+  if (season.state !== 'registration_open') {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <p className="text-zinc-500">League registration is currently closed.</p>
+      </main>
+    )
+  }
+
+  const { data: registration } = await supabase
+    .from('league_registrations')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('season_id', season.id)
+    .single()
+
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-2xl font-semibold">Join the League</h1>
+    <main className="mx-auto max-w-lg p-8">
+      <h1 className="mb-2 text-3xl font-bold">Join the League</h1>
+      <p className="mb-8 text-zinc-500">
+        Registration is open. Select up to 4 preferred teammates — they'll be guaranteed on your team.
+      </p>
+      <JoinLeagueForm
+        seasonId={season.id}
+        isRegistered={!!registration}
+      />
     </main>
   )
 }

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -39,6 +39,42 @@ export type Database = {
   }
   public: {
     Tables: {
+      league_registrations: {
+        Row: {
+          created_at: string
+          id: string
+          season_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          season_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          season_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "league_registrations_season_id_fkey"
+            columns: ["season_id"]
+            isOneToOne: false
+            referencedRelation: "seasons"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "league_registrations_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       profiles: {
         Row: {
           created_at: string
@@ -92,6 +128,52 @@ export type Database = {
           week_count?: number | null
         }
         Relationships: []
+      }
+      teammate_preferences: {
+        Row: {
+          created_at: string
+          from_user_id: string
+          id: string
+          preferred_user_id: string
+          season_id: string
+        }
+        Insert: {
+          created_at?: string
+          from_user_id: string
+          id?: string
+          preferred_user_id: string
+          season_id: string
+        }
+        Update: {
+          created_at?: string
+          from_user_id?: string
+          id?: string
+          preferred_user_id?: string
+          season_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "teammate_preferences_from_user_id_fkey"
+            columns: ["from_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "teammate_preferences_preferred_user_id_fkey"
+            columns: ["preferred_user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "teammate_preferences_season_id_fkey"
+            columns: ["season_id"]
+            isOneToOne: false
+            referencedRelation: "seasons"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -6,3 +6,5 @@ export type SeasonState = Database['public']['Enums']['season_state']
 
 export type Profile = Database['public']['Tables']['profiles']['Row']
 export type Season = Database['public']['Tables']['seasons']['Row']
+export type LeagueRegistration = Database['public']['Tables']['league_registrations']['Row']
+export type TeammatePreference = Database['public']['Tables']['teammate_preferences']['Row']

--- a/supabase/migrations/20240002_league_registration.sql
+++ b/supabase/migrations/20240002_league_registration.sql
@@ -1,0 +1,33 @@
+create table public.league_registrations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.profiles on delete cascade not null,
+  season_id uuid references public.seasons on delete cascade not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, season_id)
+);
+
+alter table public.league_registrations enable row level security;
+
+create policy "Users can read all registrations"
+  on public.league_registrations for select using (true);
+
+create policy "Users can manage their own registration"
+  on public.league_registrations for all using (auth.uid() = user_id);
+
+create table public.teammate_preferences (
+  id uuid primary key default gen_random_uuid(),
+  from_user_id uuid references public.profiles on delete cascade not null,
+  preferred_user_id uuid references public.profiles on delete cascade not null,
+  season_id uuid references public.seasons on delete cascade not null,
+  created_at timestamptz not null default now(),
+  unique (from_user_id, preferred_user_id, season_id),
+  check (from_user_id != preferred_user_id)
+);
+
+alter table public.teammate_preferences enable row level security;
+
+create policy "Users can read all teammate preferences"
+  on public.teammate_preferences for select using (true);
+
+create policy "Users can manage their own preferences"
+  on public.teammate_preferences for all using (auth.uid() = from_user_id);


### PR DESCRIPTION
## Parent
#1

## Summary
- `/league/join` shows join form when `registration_open`, closed message otherwise
- Teammate search auto-suggests registered users by name (min 2 chars, excludes self and already-selected)
- Up to 4 teammates selectable as pills; removable before submit
- Joining creates `league_registrations` + `teammate_preferences` rows
- Registered users see confirmation and a Leave League button (only works while `registration_open`)
- New migration: `league_registrations` and `teammate_preferences` tables with RLS

## Test plan
- [ ] Register and visit `/league/join` — see join form
- [ ] Search for a teammate by name — suggestions appear
- [ ] Join league — row appears in `league_registrations`
- [ ] Revisit `/league/join` — see registered state and leave button
- [ ] Leave league — row removed
- [ ] Advance season past `registration_open` — join/leave blocked with message

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)